### PR TITLE
Fixes accession extraction from MAG filenames with format MGYG*.fna

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -15,7 +15,7 @@ with open(MAP_NAMES_PATH, 'r') as jsonfile:
 
 
 def get_accession_from_filename(filename):
-    accesion = filename[filename.rfind("/")+1:].replace(".fa","")
+    accesion = filename[filename.rfind("/")+1:].replace(".fa","").replace(".fna","")
     if accesion.startswith("GUT_"):
         if accesion in name_map:
             return name_map[accesion]


### PR DESCRIPTION
New catalogues will have MAGs with filenames ending `.fna` instead of `.fa`. This PR makes sure accessions are correctly extracted in both cases.